### PR TITLE
Gstreamer improvement, video saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ The work here builds on the work done by Adrian Lopez-Rodriguez and Nelson Da Si
 5. (On camera machine): Start webcam stream: `./scripts/camera_stream_tx.sh <server_ip>`
 6. (On Jetson) Start server headless: `./scripts/start_server_headless.sh`
 	- _Optional:_ view logs with `tail -f ./logs/server_log.txt`
-	- _To start from shell within docker container instead:_: `./scripts/start_docker.sh`, then `python3 run_server_sync.py`
+	- _To start from shell within docker container instead:_ `./scripts/start_docker.sh`, then `python3 run_server_sync.py`
+	- _To save the output annotated video frames:_ use `python3 run_server_sync.py --save_video`. This will cause a significant drop in framerate.
 7. (On client) Start test client: `python3 -m pip install argparse jsonrpclib-pelix && python3 run_client_test.py -a http://<server_ip>:8080`
 	- The `http://` and port number are necessary.
+
 
 Server tested on Python 3.8.10 running on a Jetson Orin NX running L4T r35.3.1. Client tested on Python 3.10.8.
 

--- a/run_server_sync.py
+++ b/run_server_sync.py
@@ -15,7 +15,7 @@ class ServerSync:
     def __init__(self, args):
         self.args = args
         if self.args.save_video:
-            self.video_save_dir = os.path.join("saved_runs", f"capture_{time.strftime('%Y-%m-%d_%H-%M-%S')}}")
+            self.video_save_dir = os.path.join("saved_runs", f"capture_{time.strftime('%Y-%m-%d_%H-%M-%S')}")
             print(f"Saving video capture to {self.video_save_dir}")
         self.video = VideoCaptureThreading(f'\
                  udpsrc port={args.video_port} \

--- a/run_server_sync.py
+++ b/run_server_sync.py
@@ -16,6 +16,8 @@ class ServerSync:
         self.args = args
         if self.args.save_video:
             self.video_save_dir = os.path.join("saved_runs", f"capture_{time.strftime('%Y-%m-%d_%H-%M-%S')}")
+            if not os.path.exists(self.video_save_dir):
+                os.makedirs(self.video_save_dir)
             print(f"Saving video capture to {self.video_save_dir}")
         self.video = VideoCaptureThreading(f'\
                  udpsrc port={args.video_port} \

--- a/run_server_sync.py
+++ b/run_server_sync.py
@@ -15,12 +15,14 @@ class ServerSync:
         self.args = args
         self.video = VideoCaptureThreading(f'\
                  udpsrc port={args.video_port} \
-                 ! application/x-rtp,encoding-name=H264,payload=96 \
+                 ! application/x-rtp,clock-rate=90000,encoding-name=H264,payload=96 \
+                 ! rtpjitterbuffer latency-1000 \
                  ! rtph264depay \
+                 ! queue \
                  ! avdec_h264 \
                  ! videoconvert \
                  ! video/x-raw,format=BGR \
-                 ! appsink sync=false drop=true \
+                 ! appsink sync=false \
                  ', cv2.CAP_GSTREAMER)
         self.engine = TRTBaseEngine(engine_path=self.args.checkpoint, imgsz=(self.args.resolution[0], self.args.resolution[1]))
 

--- a/run_server_sync.py
+++ b/run_server_sync.py
@@ -22,7 +22,7 @@ class ServerSync:
         self.video = VideoCaptureThreading(f'\
                  udpsrc port={args.video_port} \
                  ! application/x-rtp,clock-rate=90000,encoding-name=H264,payload=96 \
-                 ! rtpjitterbuffer latency-1000 \
+                 ! rtpjitterbuffer latency=1000 \
                  ! rtph264depay \
                  ! queue \
                  ! avdec_h264 \

--- a/scripts/camera_stream_rx.sh
+++ b/scripts/camera_stream_rx.sh
@@ -9,7 +9,7 @@ fi
 
 echo Receiving stream on port $port
 # For h264 - sends partial frames and can lead to corrupted images on receiving end
-gst-launch-1.0 -v udpsrc port=$port ! application/x-rtp,encoding-name=H264,payload=96 ! rtph264depay ! avdec_h264 ! videoconvert ! ximagesink sync=false
+gst-launch-1.0 -v udpsrc port=$port ! application/x-rtp,encoding-name=H264,payload=96 ! rtph264depay ! avdec_h264 ! videoconvert ! autovideosink sync=false
 
 # For JPEG - no corruption visible
 #gst-launch-1.0 -v udpsrc port=5000 ! application/x-rtp,encoding-name=JPEG,payload=96 ! rtpjpegdepay ! jpegdec ! videoconvert ! ximagesink sync=false

--- a/scripts/camera_stream_tx_bayer_format.sh
+++ b/scripts/camera_stream_tx_bayer_format.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Begin streaming existing video stream to target IP.
+
+ip=172.22.83.251
+port=5000
+if [ $# -gt 0 ]
+then
+    ip=$1
+fi
+
+echo Streaming to $ip on port $port
+# For converting MJPEG camera output to H264. Can result in dropped/partial frames on receiving end (looks like washed out grey video)
+gst-launch-1.0 -v v4l2src device=/dev/video0 ! video/x-bayer,format=grbg ! bayer2rgb ! videoconvert ! video/x-raw ! x264enc tune=zerolatency ! rtph264pay ! application/x-rtp,encoding-name=H264,payload=96 ! udpsink host=$ip port=$port
+
+# For sending MJPEG camera stream directly.
+#gst-launch-1.0 -v v4l2src device=/dev/video0 ! image/jpeg,frame-rate=30/1 ! rtpjpegpay ! udpsink host=$ip port=$port

--- a/test_trt_webcam.py
+++ b/test_trt_webcam.py
@@ -15,7 +15,7 @@ most_recent_results = {}
 def main(args):
     print("Setting up video stream")
     video = VideoCaptureThreading('\
-            udpsrc address=192.168.53.42 port=5000 \
+            udpsrc port=5000 \
             ! application/x-rtp,clock-rate=90000,encoding-name=H264,payload=96 \
             ! rtpjitterbuffer latency=1000 \
             ! rtph264depay \

--- a/test_trt_webcam.py
+++ b/test_trt_webcam.py
@@ -16,6 +16,8 @@ most_recent_results = {}
 def main(args):
     if args.save_video:
         video_save_dir = os.path.join("saved_runs", f"capture_{time.strftime('%Y-%m-%d_%H-%M-%S')}")
+        if not os.path.exists(video_save_dir):
+            os.makedirs(video_save_dir)
         print(f"Saving video capture to {video_save_dir}")
 
     print("Setting up video stream")

--- a/test_trt_webcam.py
+++ b/test_trt_webcam.py
@@ -5,7 +5,6 @@ import argparse
 import os
 import cv2
 import time
-import datetime
 import json
 
 import yolojetson.utils

--- a/test_trt_webcam.py
+++ b/test_trt_webcam.py
@@ -15,7 +15,7 @@ most_recent_results = {}
 
 def main(args):
     if args.save_video:
-        video_save_dir = os.path.join("saved_runs", f"capture_{time.strftime('%Y-%m-%d_%H-%M-%S')}}")
+        video_save_dir = os.path.join("saved_runs", f"capture_{time.strftime('%Y-%m-%d_%H-%M-%S')}")
         print(f"Saving video capture to {video_save_dir}")
 
     print("Setting up video stream")

--- a/yolojetson/TRTBaseEngine.py
+++ b/yolojetson/TRTBaseEngine.py
@@ -45,7 +45,7 @@ class TRTBaseEngine(object):
         assert os.path.exists(engine_path)
         print(f"Reading engine from file {engine_path}")
         with open(engine_path, "rb") as f:
-            return self.runtime(deserialize_cuda_engine(f.read()))
+            return self.runtime.deserialize_cuda_engine(f.read())
 
                 
     def _infer(self, img):


### PR DESCRIPTION
This is a continuation of PR #1 that:
* Fixes a typo in one of the gstreamer pipelines
* Removes a source IP from one gstreamer pipeline for udpsrc as it isn't needed to receive video from another machine (it just listens for incoming traffic on the specified port)
* Adds a `--save_video` flag to both `test_trt_webcam.py` and `run_server_sync.py` that saves annotated frames to a directory
* Updates the README to reflect these changes